### PR TITLE
Update scala-github-actions workflows to v7.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,13 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        scala:
-          - 2.13.12
-          - 2.12.18
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
-
-      - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
-
-      - name: test coverage
-        if: success()
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
-
-      - name: slack
-        uses: homoluctus/slatify@master
-        if: failure() && github.ref == 'refs/heads/master'
-        with:
-          type: ${{ job.status }}
-          job_name: Build
-          url: ${{ secrets.SLACK_WEBHOOK }}
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@61f111a4472fde7b63e5921ac8a238f22d1bb028 # v7.0.1

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,12 @@
+name: Dependency graph
+
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    uses: evolution-gaming/scala-github-actions/.github/workflows/dependency-graph.yml@61f111a4472fde7b63e5921ac8a238f22d1bb028 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,14 @@
-name: Publish new Release
+name: Publish Release
 
 on:
-  release:
-    types: [published]
-    branches: [master]
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # can delete tag on failed release attempt
 
 jobs:
   release:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
+    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@61f111a4472fde7b63e5921ac8a238f22d1bb028 # v7.0.1
     secrets: inherit

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,96 @@
+# Main goals:
+# - nicer commit diffs (trailing commas, no alignment for pattern matching, force new lines)
+# - better interop with default IntelliJ IDEA setup (matching import and modifiers sorting logic)
+# - better developer experience on laptop screens (like 16' MBPs) with IntelliJ IDEA (line wraps)
+
+version = 3.11.5
+
+runner.dialect = scala213source3
+
+# only format files tracked by git
+project.git = true
+
+maxColumn = 120
+trailingCommas = always
+
+preset = default
+# do not align to make nicer commit diffs
+align.preset = none
+
+indent {
+  # altering defnSite and extendSite to have this:
+  #   final class MyErr extends RuntimeException(
+  #     "super error message",
+  #   )
+  # instead of this:
+  #   final class MyErr extends RuntimeException(
+  #       "super error message",
+  #     )
+  defnSite = 2
+  extendSite = 0
+}
+
+spaces {
+  # makes string interpolation with curlies more visually distinct
+  inInterpolatedStringCurlyBraces = true
+}
+
+newlines {
+  # keep author new lines where possible
+  source = keep
+  # force new line after "(implicit" for multi-line arg lists
+  implicitParamListModifierForce = [after]
+  avoidForSimpleOverflow = [
+    tooLong, # if the line would be too long even after newline inserted, do nothing
+    slc, # do nothing if overflow caused by single line comment
+  ]
+}
+
+verticalMultiline {
+  atDefnSite = true
+  arityThreshold = 4 # more than 3 args in a list will be turned vertical
+  newlineAfterOpenParen = true # for nicer commit diffs
+}
+
+# for nicer commit diffs - forces new line before last parenthesis:
+#   class MyCls(
+#     arg1: String,
+#     arg2: String,
+#   ) extends MyTrait {
+#
+# without it:
+#   class MyCls(
+#     arg1: String,
+#     arg2: String) extends MyTrait {
+danglingParentheses.exclude = []
+
+docstrings {
+  # easier to view diffs in IDEA on 16' MBP screen if docs max line are shorter than code
+  wrapMaxColumn = 100
+  # next settings make it similar to the default IDEA javadoc formatting
+  style = Asterisk
+  oneline = unfold
+  blankFirstLine = unfold
+}
+
+rewrite.rules = [
+  Imports,
+  RedundantParens,
+  SortModifiers,
+  prefercurlyfors,
+]
+
+# put visibility modifier first
+rewrite.sortModifiers.preset = styleGuide
+
+# Import sorting as similar as possible to scalafix's "OrganizeImports.preset = INTELLIJ_2020_3".
+# Scalafix is not used as its commands mess up "all .." build aliases and it takes long time to run,
+# while its code semantic based features are not needed here.
+# I.e. detection of unused imports is done with Scala compiler options.
+rewrite.imports {
+  sort = ascii
+  groups = [
+    [".*"],
+    ["java\\..*", "javax\\..*", "scala\\..*"],
+  ]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import Dependencies._
+import Dependencies.*
 
 name := "patch"
 
@@ -14,29 +14,60 @@ organizationHomepage := Some(url("https://evolution.com"))
 
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.13.12", "2.12.18")
+crossScalaVersions := Seq("2.13.18", "3.3.8")
 
 publishTo := Some(Resolver.evolutionReleases)
 
-libraryDependencies += compilerPlugin(`kind-projector` cross CrossVersion.full)
+libraryDependencies ++= {
+  scalaBinaryVersion.value match {
+    case "2.13" => Seq(compilerPlugin(`kind-projector`.cross(CrossVersion.full)))
+    case _ => Nil
+  }
+}
 
 scalacOptsFailOnWarn := Some(false)
 
+scalacOptions ++= {
+  scalaBinaryVersion.value match {
+    case "2.13" =>
+      Seq(
+        "-Xsource:3",
+      )
+    case _ =>
+      Seq(
+        "-Ykind-projector:underscores",
+
+        // disable new brace-less syntax:
+        // https://alexn.org/blog/2022/10/24/scala-3-optional-braces/
+        "-no-indent",
+
+        // improve error messages:
+        "-explain",
+        "-explain-types",
+      )
+  }
+}
+
 libraryDependencies ++= Seq(
   Cats.core,
-  Cats.laws              % Test,
-  `cats-effect`          % Test,
-  scalatest              % Test,
-  `scalacheck-shapeless` % Test,
+  Cats.laws % Test,
+  `cats-effect` % Test,
+  scalatest % Test,
   `discipline-scalatest` % Test,
 )
 
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
-releaseCrossBuild := true
-
 versionScheme := Some("early-semver")
 
-//addCommandAlias("check", "all versionPolicyCheck Compile/doc")
-addCommandAlias("check", "show version")
+versionPolicyIntention := {
+  // TODO temporary disable bin-compat check for first Scala 3 build
+  scalaBinaryVersion.value match {
+    case "2.13" => Compatibility.BinaryCompatible
+    case _ => Compatibility.None
+  }
+}
+
+addCommandAlias("check", "+all scalafmtCheckRepo versionPolicyCheck Compile/doc")
+addCommandAlias("fmt", "scalafmtRepo")
 addCommandAlias("build", "+all compile test")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,17 +2,14 @@ import sbt._
 
 object Dependencies {
 
-  val scalatest = "org.scalatest" %% "scalatest" % "3.2.8"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.2.20"
 
-  val `kind-projector`       = "org.typelevel"  % "kind-projector"       % "0.13.2"
+  val `kind-projector` = "org.typelevel" % "kind-projector" % "0.13.4"
   val `discipline-scalatest` = "org.typelevel" %% "discipline-scalatest" % "2.2.0"
-  val `cats-effect`          = "org.typelevel" %% "cats-effect"          % "3.4.8"
-
-  val `scalacheck-shapeless` = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5"
-
+  val `cats-effect` = "org.typelevel" %% "cats-effect" % "3.7.1"
 
   object Cats {
-    private val version = "2.9.0"
+    private val version = "2.13.0"
     val core = "org.typelevel" %% "cats-core" % version
     val laws = "org.typelevel" %% "cats-laws" % version
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version = 1.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,11 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.9")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
+addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.2.0")
 
-addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
+addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")
 
-addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.3.0")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")

--- a/src/main/scala/com/evolution/patch/Derive.scala
+++ b/src/main/scala/com/evolution/patch/Derive.scala
@@ -11,7 +11,10 @@ trait Derive[A, B, C] {
 
 object Derive extends DeriveImplicits0 {
 
-  def apply[A, B, C](implicit derive: Derive[A, B, C]): Derive[A, B, C] = derive
+  def apply[A, B, C](
+    implicit
+    derive: Derive[A, B, C],
+  ): Derive[A, B, C] = derive
 
   def fromMonoid[A: Monoid]: Derive[A, A, A] = new Derive[A, A, A] {
     def apply(a: A, b: A) = Monoid[A].combine(a, b)
@@ -24,7 +27,6 @@ object Derive extends DeriveImplicits0 {
     override def toString = "Derive.productRight"
   }
 
-
   implicit def rightDerive[A]: Derive[Unit, A, A] = new Derive[Unit, A, A] {
 
     def apply(a: Unit, b: A) = b
@@ -32,11 +34,14 @@ object Derive extends DeriveImplicits0 {
     override def toString = "Derive.right"
   }
 
-
   object implicits {
 
     implicit class IdOpsDerive[A](val self: A) extends AnyVal {
-      def derive[B, C](b: B)(implicit derive: Derive[A, B, C]): C = derive(self, b)
+      def derive[B, C](
+        b: B,
+      )(implicit
+        derive: Derive[A, B, C],
+      ): C = derive(self, b)
     }
   }
 }
@@ -49,7 +54,6 @@ sealed abstract class DeriveImplicits0 extends DeriveImplicits1 {
 
     override def toString = "Derive.left"
   }
-
 
   implicit def productLeftDerive[F[_]: Apply, A]: Derive[F[A], F[Unit], F[A]] = new Derive[F[A], F[Unit], F[A]] {
 

--- a/src/main/scala/com/evolution/patch/Patch.scala
+++ b/src/main/scala/com/evolution/patch/Patch.scala
@@ -4,37 +4,39 @@ import cats.data.{AndThen, EitherT}
 import cats.syntax.all._
 import cats.{Applicative, FlatMap, Functor, Monad, MonadError, Monoid, StackSafeMonad, ~>}
 
-/** This monadic data structure helps to describe changes to state as events and
-  * combine them together as well as relevant effects
-  *
-  * @tparam M
-  *   A *monad* to be used to capture the effectful computation when doing a
-  *   patch such as [[cats.effect.IO]]. The common use case is to use it to
-  *   raise an error found if validation or other effectful process failed.
-  * @tparam S
-  *   A *state* to update when calling [[Patch#event]], or retain when calling
-  *   other methods.
-  * @tparam E
-  *   A type of *events* to accumulate when calling [[Patch#event]] method or
-  *   retain when calling other methods.
-  * @tparam F
-  *   A type of *effects* to be executed after the produced events are confirmed
-  *   to be persisted. When doing [[Patch#flatMap]] the effects will
-  *   accumulate into a single value using provided `Monoid[F]` instance. I.e.
-  *   if `F = IO[Unit]` then `fa`, `fb` and `fc` will accumulate to `fa *> fb *>
-  *   fc`. Note that `F` does not have to be anyhow related to `M[_]`.
-  * @tparam A
-  *   A *result* of the function. Also used as an argument in [[Patch#map]] and
-  *   [[Patch#flatMap]].
-  */
+/**
+ * This monadic data structure helps to describe changes to state as events and combine them
+ * together as well as relevant effects
+ *
+ * @tparam M
+ *   A *monad* to be used to capture the effectful computation when doing a patch such as
+ *   [[cats.effect.IO]]. The common use case is to use it to raise an error found if validation or
+ *   other effectful process failed.
+ * @tparam S
+ *   A *state* to update when calling [[Patch#event]], or retain when calling other methods.
+ * @tparam E
+ *   A type of *events* to accumulate when calling [[Patch#event]] method or retain when calling
+ *   other methods.
+ * @tparam F
+ *   A type of *effects* to be executed after the produced events are confirmed to be persisted.
+ *   When doing [[Patch#flatMap]] the effects will accumulate into a single value using provided
+ *   `Monoid[F]` instance. I.e. if `F = IO[Unit]` then `fa`, `fb` and `fc` will accumulate to `fa *>
+ *   fb *> fc`. Note that `F` does not have to be anyhow related to `M[_]`.
+ * @tparam A
+ *   A *result* of the function. Also used as an argument in [[Patch#map]] and [[Patch#flatMap]].
+ */
 sealed abstract case class Patch[M[_], S, E, F, A] private (
-  io: Patch.In[S, E] => M[Patch.Out[S, E, F, A]]
+  io: Patch.In[S, E] => M[Patch.Out[S, E, F, A]],
 ) {
   self =>
 
   import Patch._
 
-  def map[B](f: A => B)(implicit M: Functor[M]): Patch[M, S, E, F, B] = {
+  def map[B](
+    f: A => B,
+  )(implicit
+    M: Functor[M],
+  ): Patch[M, S, E, F, B] = {
     of {
       AndThen
         .apply(io)
@@ -45,8 +47,11 @@ sealed abstract case class Patch[M[_], S, E, F, A] private (
   }
 
   def flatMap[F1, F2, B](
-    f: A => Patch[M, S, E, F1, B]
-  )(implicit M: FlatMap[M], derive: Derive[F, F1, F2]): Patch[M, S, E, F2, B] = {
+    f: A => Patch[M, S, E, F1, B],
+  )(implicit
+    M: FlatMap[M],
+    derive: Derive[F, F1, F2],
+  ): Patch[M, S, E, F2, B] = {
     of {
       AndThen
         .apply(io)
@@ -62,9 +67,16 @@ sealed abstract case class Patch[M[_], S, E, F, A] private (
     }
   }
 
-  def as[B](value: B)(implicit M: Functor[M]): Patch[M, S, E, F, B] = map { _ => value }
+  def as[B](
+    value: B,
+  )(implicit
+    M: Functor[M],
+  ): Patch[M, S, E, F, B] = map { _ => value }
 
-  def unit(implicit M: Functor[M]): Patch[M, S, E, F, Unit] = as(())
+  def unit(
+    implicit
+    M: Functor[M],
+  ): Patch[M, S, E, F, Unit] = as(())
 
   def monad: MonadProjection[M, S, E, F, A] = new MonadProjection(self)
 
@@ -74,7 +86,12 @@ sealed abstract case class Patch[M[_], S, E, F, A] private (
 
   def effect: EffectProjection[M, S, E, F, A] = new EffectProjection(self)
 
-  def run(state: S, seqNr: SeqNr)(implicit M: Monad[M]): M[Result[S, E, F, A]] = {
+  def run(
+    state: S,
+    seqNr: SeqNr,
+  )(implicit
+    M: Monad[M],
+  ): M[Result[S, E, F, A]] = {
     val in = In(state, seqNr, List.empty[E])
     self
       .io(in)
@@ -91,8 +108,11 @@ object Patch extends PatchInstances2 {
   private[Patch] class PartiallyApplied[S](val b: Boolean = false) extends AnyVal {
 
     def apply[M[_], E, F, A](
-      f: (S, SeqNr) => M[(Option[(S, E)], F, A)]
-    )(implicit maker: Maker[M, S, E], M: Functor[M]): Patch[M, S, E, F, A] = {
+      f: (S, SeqNr) => M[(Option[(S, E)], F, A)],
+    )(implicit
+      maker: Maker[M, S, E],
+      M: Functor[M],
+    ): Patch[M, S, E, F, A] = {
       maker.apply(f)
     }
   }
@@ -102,39 +122,73 @@ object Patch extends PatchInstances2 {
   private[Patch] class ChangePartiallyApplied[S](val b: Boolean = false) extends AnyVal {
 
     def apply[M[_], E, F, A](
-      f: (S, SeqNr) => M[(S, E, F, A)]
-    )(implicit maker: Maker[M, S, E], M: Functor[M]): Patch[M, S, E, F, A] = {
+      f: (S, SeqNr) => M[(S, E, F, A)],
+    )(implicit
+      maker: Maker[M, S, E],
+      M: Functor[M],
+    ): Patch[M, S, E, F, A] = {
       maker.change(f)
     }
   }
 
-  def state[M[_], S, E](implicit maker: Maker[M, S, E], M: Applicative[M]): Patch[M, S, E, Unit, S] = {
+  def state[M[_], S, E](
+    implicit
+    maker: Maker[M, S, E],
+    M: Applicative[M],
+  ): Patch[M, S, E, Unit, S] = {
     maker.state
   }
 
-  def seqNr[M[_], S, E](implicit maker: Maker[M, S, E], M: Applicative[M]): Patch[M, S, E, Unit, SeqNr] = {
+  def seqNr[M[_], S, E](
+    implicit
+    maker: Maker[M, S, E],
+    M: Applicative[M],
+  ): Patch[M, S, E, Unit, SeqNr] = {
     maker.seqNr
   }
 
-  def events[M[_], S, E](implicit maker: Maker[M, S, E], M: Applicative[M]): Patch[M, S, E, Unit, List[E]] = {
+  def events[M[_], S, E](
+    implicit
+    maker: Maker[M, S, E],
+    M: Applicative[M],
+  ): Patch[M, S, E, Unit, List[E]] = {
     maker.events
   }
 
-  def pure[M[_], S, E, A](value: A)(implicit maker: Maker[M, S, E], M: Applicative[M]): Patch[M, S, E, Unit, A] = {
+  def pure[M[_], S, E, A](
+    value: A,
+  )(implicit
+    maker: Maker[M, S, E],
+    M: Applicative[M],
+  ): Patch[M, S, E, Unit, A] = {
     maker.pure(value)
   }
 
-  def lift[M[_], S, E, A](value: M[A])(implicit maker: Maker[M, S, E], M: Functor[M]): Patch[M, S, E, Unit, A] = {
+  def lift[M[_], S, E, A](
+    value: M[A],
+  )(implicit
+    maker: Maker[M, S, E],
+    M: Functor[M],
+  ): Patch[M, S, E, Unit, A] = {
     maker.lift(value)
   }
 
   def event[M[_], S, E](
-    event: E
-  )(implicit maker: Maker[M, S, E], M: Functor[M], change: Change[M, S, E]): Patch[M, S, E, Unit, Unit] = {
+    event: E,
+  )(implicit
+    maker: Maker[M, S, E],
+    M: Functor[M],
+    change: Change[M, S, E],
+  ): Patch[M, S, E, Unit, Unit] = {
     maker.event(event)
   }
 
-  def effect[M[_], S, E, F](effect: F)(implicit maker: Maker[M, S, E], M: Applicative[M]): Patch[M, S, E, F, Unit] = {
+  def effect[M[_], S, E, F](
+    effect: F,
+  )(implicit
+    maker: Maker[M, S, E],
+    M: Applicative[M],
+  ): Patch[M, S, E, F, Unit] = {
     maker.effect(effect)
   }
 
@@ -147,7 +201,13 @@ object Patch extends PatchInstances2 {
     }
   }
 
-  final case class Result[S, E, F, A](state: S, seqNr: SeqNr, events: List[E], effect: F, value: A)
+  final case class Result[S, E, F, A](
+    state: S,
+    seqNr: SeqNr,
+    events: List[E],
+    effect: F,
+    value: A,
+  )
 
   trait Change[F[_], S, E] {
     def apply(state: S, seqNr: SeqNr, event: E): F[S]
@@ -171,7 +231,11 @@ object Patch extends PatchInstances2 {
 
   implicit class PatchOps[M[_], S, E, F, A](val self: Patch[M, S, E, F, A]) extends AnyVal {
 
-    def optional[Er](implicit M: MonadError[M, Er], monoid: Monoid[F]): Patch[M, S, E, F, Option[A]] = {
+    def optional[Er](
+      implicit
+      M: MonadError[M, Er],
+      monoid: Monoid[F],
+    ): Patch[M, S, E, F, Option[A]] = {
       of { in =>
         self
           .io(in)
@@ -181,16 +245,25 @@ object Patch extends PatchInstances2 {
     }
   }
 
-  implicit class PatchPatchOps[M[_], S, E, F, F1, A](val self: Patch[M, S, E, F, Patch[M, S, E, F1, A]]) extends AnyVal {
+  implicit class PatchPatchOps[M[_], S, E, F, F1, A](val self: Patch[M, S, E, F, Patch[M, S, E, F1, A]])
+  extends AnyVal {
 
-    def flatten1[F2](implicit M: FlatMap[M], derive: Derive[F, F1, F2]): Patch[M, S, E, F2, A] = {
+    def flatten1[F2](
+      implicit
+      M: FlatMap[M],
+      derive: Derive[F, F1, F2],
+    ): Patch[M, S, E, F2, A] = {
       self.flatMap(identity)
     }
   }
 
   private[patch] class EffectProjection[M[_], S, E, F, A](val self: Patch[M, S, E, F, A]) extends AnyVal {
 
-    def map[F1](f: F => F1)(implicit M: Functor[M]): Patch[M, S, E, F1, A] = {
+    def map[F1](
+      f: F => F1,
+    )(implicit
+      M: Functor[M],
+    ): Patch[M, S, E, F1, A] = {
       of {
         AndThen
           .apply(self.io)
@@ -202,7 +275,12 @@ object Patch extends PatchInstances2 {
       }
     }
 
-    def add[F1, F2](effect: F1)(implicit M: Monad[M], derive: Derive[F, F1, F2]): Patch[M, S, E, F2, A] = {
+    def add[F1, F2](
+      effect: F1,
+    )(implicit
+      M: Monad[M],
+      derive: Derive[F, F1, F2],
+    ): Patch[M, S, E, F2, A] = {
       of {
         AndThen
           .apply(self.io)
@@ -228,7 +306,12 @@ object Patch extends PatchInstances2 {
 
   private[patch] class StateProjection[M[_], S, E, F, A](val self: Patch[M, S, E, F, A]) extends AnyVal {
 
-    def map[S1](toS: S => S1, toS1: S1 => S)(implicit M: Functor[M]): Patch[M, S1, E, F, A] = {
+    def map[S1](
+      toS: S => S1,
+      toS1: S1 => S,
+    )(implicit
+      M: Functor[M],
+    ): Patch[M, S1, E, F, A] = {
       of { in =>
         self
           .io
@@ -241,11 +324,17 @@ object Patch extends PatchInstances2 {
       }
     }
 
-    def flatMap[S1](toS: S => M[S1])(toS1: S1 => M[S])(implicit M: FlatMap[M]): Patch[M, S1, E, F, A] = {
+    def flatMap[S1](
+      toS: S => M[S1],
+    )(
+      toS1: S1 => M[S],
+    )(implicit
+      M: FlatMap[M],
+    ): Patch[M, S1, E, F, A] = {
       of { in =>
         for {
           state <- toS1(in.state)
-          out   <- self.io { in.copy(state = state) }
+          out <- self.io { in.copy(state = state) }
           state <- toS(out.state)
         } yield {
           out.copy(state = state)
@@ -256,7 +345,12 @@ object Patch extends PatchInstances2 {
 
   private[patch] class EventProjection[M[_], S, E, F, A](val self: Patch[M, S, E, F, A]) extends AnyVal {
 
-    def map[E1](toE1: E => E1, toE: E1 => E)(implicit M: Functor[M]): Patch[M, S, E1, F, A] = {
+    def map[E1](
+      toE1: E => E1,
+      toE: E1 => E,
+    )(implicit
+      M: Functor[M],
+    ): Patch[M, S, E1, F, A] = {
       of { in =>
         self
           .io
@@ -264,14 +358,14 @@ object Patch extends PatchInstances2 {
             in.copy(
               events = in
                 .events
-                .map(toE)
+                .map(toE),
             )
           }
           .map { out =>
             out.copy(
               events = out
                 .events
-                .map(toE1)
+                .map(toE1),
             )
           }
       }
@@ -282,7 +376,13 @@ object Patch extends PatchInstances2 {
     def out[F, A](effect: F, a: A): Out[S, E, F, A] = Out(state, seqNr, events, effect, a)
   }
 
-  private[patch] final case class Out[S, E, F, A](state: S, seqNr: SeqNr, events: List[E], effect: F, a: A) {
+  private[patch] final case class Out[S, E, F, A](
+    state: S,
+    seqNr: SeqNr,
+    events: List[E],
+    effect: F,
+    a: A,
+  ) {
     def in: In[S, E] = In(state, seqNr, events)
   }
 
@@ -291,7 +391,8 @@ object Patch extends PatchInstances2 {
     implicit class EitherOpsPatch[F[_], L, R](val self: Either[L, R]) extends AnyVal {
 
       def patchEitherTLift[S, E](
-        implicit maker: Maker[EitherT[F, L, *], S, E],
+        implicit
+        maker: Maker[EitherT[F, L, *], S, E],
         F: Monad[F],
       ): Patch[EitherT[F, L, *], S, E, Unit, R] = {
         self
@@ -301,12 +402,17 @@ object Patch extends PatchInstances2 {
     }
 
     implicit class OpsPatch[M[_], A](val self: M[A]) extends AnyVal {
-      def patchLift[S, E](implicit maker: Maker[M, S, E], M: Functor[M]): Patch[M, S, E, Unit, A] = maker.lift(self)
+      def patchLift[S, E](
+        implicit
+        maker: Maker[M, S, E],
+        M: Functor[M],
+      ): Patch[M, S, E, Unit, A] = maker.lift(self)
 
       // TODO TECH-756 how could we get rid of this?
       def patchEitherTLift[Er, S, E](
-        implicit maker: Maker[EitherT[M, Er, *], S, E],
-        M: Monad[M]
+        implicit
+        maker: Maker[EitherT[M, Er, *], S, E],
+        M: Monad[M],
       ): Patch[EitherT[M, Er, *], S, E, Unit, A] = {
         maker.lift { EitherT.right[Er] { self } }
       }
@@ -314,38 +420,81 @@ object Patch extends PatchInstances2 {
 
     implicit class IdOpsPatch[A](val self: A) extends AnyVal {
       def patchEvent[M[_], S](
-        implicit maker: Maker[M, S, A],
+        implicit
+        maker: Maker[M, S, A],
         change: Change[M, S, A],
-        M: Functor[M]
+        M: Functor[M],
       ): Patch[M, S, A, Unit, Unit] = maker.event(self)
 
-      def patch[M[_], S, E](implicit maker: Maker[M, S, E], M: Applicative[M]): Patch[M, S, E, Unit, A] =
+      def patch[M[_], S, E](
+        implicit
+        maker: Maker[M, S, E],
+        M: Applicative[M],
+      ): Patch[M, S, E, Unit, A] =
         maker.pure(self)
 
-      def patchEffect[F[_], S, E](implicit maker: Maker[F, S, E], F: Applicative[F]): Patch[F, S, E, A, Unit] =
+      def patchEffect[F[_], S, E](
+        implicit
+        maker: Maker[F, S, E],
+        F: Applicative[F],
+      ): Patch[F, S, E, A, Unit] =
         maker.effect(self)
     }
   }
 
   trait Maker[M[_], S, E] {
 
-    def apply[F, A](f: (S, SeqNr) => M[(Option[(S, E)], F, A)])(implicit M: Functor[M]): Patch[M, S, E, F, A]
+    def apply[F, A](
+      f: (S, SeqNr) => M[(Option[(S, E)], F, A)],
+    )(implicit
+      M: Functor[M],
+    ): Patch[M, S, E, F, A]
 
-    def change[F, A](f: (S, SeqNr) => M[(S, E, F, A)])(implicit M: Functor[M]): Patch[M, S, E, F, A]
+    def change[F, A](
+      f: (S, SeqNr) => M[(S, E, F, A)],
+    )(implicit
+      M: Functor[M],
+    ): Patch[M, S, E, F, A]
 
-    def state(implicit M: Applicative[M]): Patch[M, S, E, Unit, S]
+    def state(
+      implicit
+      M: Applicative[M],
+    ): Patch[M, S, E, Unit, S]
 
-    def seqNr(implicit M: Applicative[M]): Patch[M, S, E, Unit, SeqNr]
+    def seqNr(
+      implicit
+      M: Applicative[M],
+    ): Patch[M, S, E, Unit, SeqNr]
 
-    def events(implicit M: Applicative[M]): Patch[M, S, E, Unit, List[E]]
+    def events(
+      implicit
+      M: Applicative[M],
+    ): Patch[M, S, E, Unit, List[E]]
 
-    def pure[A](value: A)(implicit M: Applicative[M]): Patch[M, S, E, Unit, A]
+    def pure[A](
+      value: A,
+    )(implicit
+      M: Applicative[M],
+    ): Patch[M, S, E, Unit, A]
 
-    def lift[A](value: M[A])(implicit M: Functor[M]): Patch[M, S, E, Unit, A]
+    def lift[A](
+      value: M[A],
+    )(implicit
+      M: Functor[M],
+    ): Patch[M, S, E, Unit, A]
 
-    def event(event: E)(implicit M: Functor[M], change: Change[M, S, E]): Patch[M, S, E, Unit, Unit]
+    def event(
+      event: E,
+    )(implicit
+      M: Functor[M],
+      change: Change[M, S, E],
+    ): Patch[M, S, E, Unit, Unit]
 
-    def effect[F](effect: F)(implicit M: Applicative[M]): Patch[M, S, E, F, Unit]
+    def effect[F](
+      effect: F,
+    )(implicit
+      M: Applicative[M],
+    ): Patch[M, S, E, F, Unit]
   }
 
   object Maker {
@@ -353,16 +502,24 @@ object Patch extends PatchInstances2 {
     def apply[M[_], S, E]: Maker[M, S, E] = {
       new Maker[M, S, E] {
 
-        def apply[F, A](f: (S, SeqNr) => M[(Option[(S, E)], F, A)])(implicit M: Functor[M]) = {
+        def apply[F, A](
+          f: (S, SeqNr) => M[(Option[(S, E)], F, A)],
+        )(implicit
+          M: Functor[M],
+        ) = {
           of { in =>
             f(in.state, in.seqNr).map {
               case (Some((s, e)), f, a) => Out(s, in.seqNr.inc, e :: in.events, f, a)
-              case (None, f, a)         => in.out(f, a)
+              case (None, f, a) => in.out(f, a)
             }
           }
         }
 
-        def change[F, A](f: (S, SeqNr) => M[(S, E, F, A)])(implicit functor: Functor[M]) = {
+        def change[F, A](
+          f: (S, SeqNr) => M[(S, E, F, A)],
+        )(implicit
+          functor: Functor[M],
+        ) = {
           of { in =>
             f(in.state, in.seqNr).map {
               case (s, e, f, a) => Out(s, in.seqNr.inc, e :: in.events, f, a)
@@ -370,7 +527,10 @@ object Patch extends PatchInstances2 {
           }
         }
 
-        def state(implicit M: Applicative[M]) = {
+        def state(
+          implicit
+          M: Applicative[M],
+        ) = {
           of { in =>
             in
               .out((), in.state)
@@ -378,7 +538,10 @@ object Patch extends PatchInstances2 {
           }
         }
 
-        def seqNr(implicit M: Applicative[M]) = {
+        def seqNr(
+          implicit
+          M: Applicative[M],
+        ) = {
           of { in =>
             in
               .out((), in.seqNr)
@@ -386,7 +549,10 @@ object Patch extends PatchInstances2 {
           }
         }
 
-        def events(implicit M: Applicative[M]) = {
+        def events(
+          implicit
+          M: Applicative[M],
+        ) = {
           of { in =>
             in
               .out((), in.events.reverse)
@@ -394,7 +560,11 @@ object Patch extends PatchInstances2 {
           }
         }
 
-        def pure[A](value: A)(implicit M: Applicative[M]) = {
+        def pure[A](
+          value: A,
+        )(implicit
+          M: Applicative[M],
+        ) = {
           of { in =>
             in
               .out((), value)
@@ -402,7 +572,11 @@ object Patch extends PatchInstances2 {
           }
         }
 
-        def lift[A](value: M[A])(implicit M: Functor[M]) = {
+        def lift[A](
+          value: M[A],
+        )(implicit
+          M: Functor[M],
+        ) = {
           of { in =>
             value.map { a =>
               in.out((), a)
@@ -410,7 +584,12 @@ object Patch extends PatchInstances2 {
           }
         }
 
-        def event(event: E)(implicit M: Functor[M], change: Change[M, S, E]) = {
+        def event(
+          event: E,
+        )(implicit
+          M: Functor[M],
+          change: Change[M, S, E],
+        ) = {
           of { in =>
             change(in.state, in.seqNr, event).map { state =>
               Out(state, in.seqNr.inc, event :: in.events, (), ())
@@ -418,7 +597,11 @@ object Patch extends PatchInstances2 {
           }
         }
 
-        def effect[F](effect: F)(implicit M: Applicative[M]) = {
+        def effect[F](
+          effect: F,
+        )(implicit
+          M: Applicative[M],
+        ) = {
           of { in =>
             in
               .out(effect, ())
@@ -434,11 +617,11 @@ object Patch extends PatchInstances2 {
   }
 }
 
-sealed abstract private[patch] class PatchInstances1 {
+private[patch] sealed abstract class PatchInstances1 {
   import Patch._
 
   implicit def monadPatch[M[_]: Monad, S, E, F: Monoid]: Monad[Patch[M, S, E, F, *]] = {
-    implicit val derive = Derive.fromMonoid[F]
+    implicit val derive: Derive[F, F, F] = Derive.fromMonoid[F]
     new Monad[Patch[M, S, E, F, *]] {
 
       def pure[A](a: A) = {
@@ -481,10 +664,11 @@ sealed abstract private[patch] class PatchInstances1 {
   }
 }
 
-sealed abstract private[patch] class PatchInstances2 extends PatchInstances1 {
+private[patch] sealed abstract class PatchInstances2 extends PatchInstances1 {
   import Patch._
 
-  implicit def monoidPatch[M[_], S, E, F, A](implicit
+  implicit def monoidPatch[M[_], S, E, F, A](
+    implicit
     maker: Maker[M, S, E],
     M: Monad[M],
     F: Monoid[F],
@@ -511,9 +695,10 @@ sealed abstract private[patch] class PatchInstances2 extends PatchInstances1 {
   }
 
   implicit def monadErrorPatch[M[_], Er, S, E, F: Monoid](
-    implicit M: MonadError[M, Er]
+    implicit
+    M: MonadError[M, Er],
   ): MonadError[Patch[M, S, E, F, *], Er] = {
-    implicit val derive = Derive.fromMonoid[F]
+    implicit val derive: Derive[F, F, F] = Derive.fromMonoid[F]
     new MonadError[Patch[M, S, E, F, *], Er] with StackSafeMonad[Patch[M, S, E, F, *]] {
 
       def pure[A](a: A) = {

--- a/src/test/scala-2.13/com/evolution/patch/PatchLawTest.scala
+++ b/src/test/scala-2.13/com/evolution/patch/PatchLawTest.scala
@@ -1,9 +1,9 @@
 package com.evolution.patch
 
-import com.evolution.patch.Patch.implicits._
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.MonadTests
 import cats.{Eq, Id}
+import com.evolution.patch.Patch.implicits._
 import org.scalacheck.Arbitrary
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.Configuration
@@ -13,7 +13,7 @@ class PatchLawTest extends AnyFunSuite with FunSuiteDiscipline with Configuratio
 
   type Patch[A] = com.evolution.patch.Patch[Id, Unit, Unit, Unit, A]
 
-  private implicit val maker = Patch.Maker[Id, Unit, Unit]
+  private implicit val maker: Patch.Maker[Id, Unit, Unit] = Patch.Maker[Id, Unit, Unit]
 
   implicit def eqPatch[A]: Eq[Patch[A]] = (x: Patch[A], y: Patch[A]) => {
 

--- a/src/test/scala/com/evolution/patch/DeriveTest.scala
+++ b/src/test/scala/com/evolution/patch/DeriveTest.scala
@@ -5,7 +5,6 @@ import com.evolution.patch.Derive.implicits._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-
 class DeriveTest extends AnyFunSuite with Matchers {
   import DeriveTest._
 
@@ -50,10 +49,16 @@ class DeriveTest extends AnyFunSuite with Matchers {
 object DeriveTest {
 
   def derive[A, B](a: A, b: B): Apply[A, B] = new Apply[A, B] {
-    def apply[C]()(implicit derive: Derive[A, B, C]): C = a.derive(b)
+    def apply[C](
+    )(implicit
+      derive: Derive[A, B, C],
+    ): C = a.derive(b)
   }
 
   trait Apply[A, B] {
-    def apply[C]()(implicit derive: Derive[A, B, C]): C
+    def apply[C](
+    )(implicit
+      derive: Derive[A, B, C],
+    ): C
   }
 }

--- a/src/test/scala/com/evolution/patch/ExampleTest.scala
+++ b/src/test/scala/com/evolution/patch/ExampleTest.scala
@@ -19,9 +19,8 @@ class ExampleTest extends AnyFunSuite with Matchers {
 
     // how to apply newly issued event to state
     implicit val change = Patch.Change[State, Event] { (state, seqNr, event) =>
-      state
-        .copy(value = state.value + event.value)
-        .pure[IO]
+      IO.pure(state
+        .copy(value = state.value + event.value))
     }
 
     import com.evolution.patch.Patch.implicits._ // adds nice syntax
@@ -32,13 +31,13 @@ class ExampleTest extends AnyFunSuite with Matchers {
 
     val patch: Patch[IO, State, Event, IO[Unit], Either[String, State]] = for {
       enabled <- enabled.patchLift // you might need to execute effect in order to decide on how to proceed
-      result  <- if (enabled) {
+      result <- if (enabled) {
         for {
           before <- Patch.state
-          _      <- Event(+1).patchEvent // event to be appended
-          after  <- Patch.state // state after event is applied
-          seqNr  <- Patch.seqNr // seqNr at this point
-          _      <- log(s"state changed from $before to $after($seqNr)").patchEffect
+          _ <- Event(+1).patchEvent // event to be appended
+          after <- Patch.state // state after event is applied
+          seqNr <- Patch.seqNr // seqNr at this point
+          _ <- log(s"state changed from $before to $after($seqNr)").patchEffect
         } yield {
           after.asRight[String]
         }

--- a/src/test/scala/com/evolution/patch/PatchTest.scala
+++ b/src/test/scala/com/evolution/patch/PatchTest.scala
@@ -15,8 +15,10 @@ import scala.util.Try
 class PatchTest extends AnyFunSuite with Matchers {
 
   test("all") {
-    implicit val P      = Patch.Maker[Id, Int, String]
-    implicit val change = Patch.Change[Int, String] { (state, _, _) => (state + 1).pure[Id] }
+    implicit val P = Patch.Maker[Id, Int, String]
+    implicit val change: Patch.Change[Id, Int, String] = Patch.Change[Int, String] { (state, _, _) =>
+      (state + 1).pure[Id]
+    }
     val patch = for {
       _ <- ().patch[Id, Int, String]
       a <- P.lift { "a".pure[Id] }
@@ -27,15 +29,18 @@ class PatchTest extends AnyFunSuite with Matchers {
       _ <- P.change { (s, _) => (s + 1, "e1", (), ()).pure[Id] }
     } yield a
     patch
-      .run(0, SeqNr.Min) shouldEqual Patch
-      .Result
-      .apply(2, 2L, List("e0", "e1"), "f", "a")
-      .pure[Id]
+      .run(0, SeqNr.Min) shouldEqual
+      Patch
+        .Result
+        .apply(2, 2L, List("e0", "e1"), "f", "a")
+        .pure[Id]
   }
 
   test("all complex") {
-    implicit val P      = Patch.Maker[Id, SeqNr, String]
-    implicit val change = Patch.Change[SeqNr, String] { (s, _, _) => (s + 1).pure[Id] }
+    implicit val P = Patch.Maker[Id, SeqNr, String]
+    implicit val change: Patch.Change[Id, SeqNr, String] = Patch.Change[SeqNr, String] { (s, _, _) =>
+      (s + 1).pure[Id]
+    }
 
     def lift[A](a: A) = {
       for {
@@ -78,16 +83,17 @@ class PatchTest extends AnyFunSuite with Matchers {
     }
 
     patch1
-      .run(0L, SeqNr.Min) shouldEqual Patch
-      .Result
-      .apply(
-        state  = 8L,
-        seqNr  = 8L,
-        events = List("0", "1", "x2", "3", "4", "x5", "6", "7"),
-        effect = ("1", ("4", "7")),
-        value  = ((0L, 1L, "1"), (3L, 4L, "4"), (6L, 7L, "7"))
-      )
-      .pure[Id]
+      .run(0L, SeqNr.Min) shouldEqual
+      Patch
+        .Result
+        .apply(
+          state = 8L,
+          seqNr = 8L,
+          events = List("0", "1", "x2", "3", "4", "x5", "6", "7"),
+          effect = ("1", ("4", "7")),
+          value = ((0L, 1L, "1"), (3L, 4L, "4"), (6L, 7L, "7")),
+        )
+        .pure[Id]
   }
 
   test("map/flatMap") {
@@ -122,14 +128,14 @@ class PatchTest extends AnyFunSuite with Matchers {
         }
         patch.run(0, 1L)
       }
-      _  = result.value shouldEqual List(1L, 2L, 3L, 4L, 4L)
-      _  = result.state shouldEqual 2
-      _  = result.events shouldEqual List("inc", "dec", "inc", "inc")
+      _ = result.value shouldEqual List(1L, 2L, 3L, 4L, 4L)
+      _ = result.state shouldEqual 2
+      _ = result.events shouldEqual List("inc", "dec", "inc", "inc")
       a <- logs.get
-      _  = a shouldEqual List.empty
+      _ = a shouldEqual List.empty
       _ <- result.effect
       a <- logs.get
-      _  = a.reverse shouldEqual List("+1", "-1", "+1", "empty", "+1")
+      _ = a.reverse shouldEqual List("+1", "-1", "+1", "empty", "+1")
     } yield {}
 
     result.unsafeRunSync()
@@ -139,10 +145,11 @@ class PatchTest extends AnyFunSuite with Matchers {
     implicit val P = Patch.Maker[Id, Unit, Unit]
     ()
       .patch
-      .run((), SeqNr.Min) shouldEqual Patch
-      .Result
-      .apply((), SeqNr.Min, List.empty, (), ())
-      .pure[Id]
+      .run((), SeqNr.Min) shouldEqual
+      Patch
+        .Result
+        .apply((), SeqNr.Min, List.empty, (), ())
+        .pure[Id]
   }
 
   test("lift") {
@@ -150,10 +157,11 @@ class PatchTest extends AnyFunSuite with Matchers {
     "a"
       .pure[Id]
       .patchLift
-      .run((), SeqNr.Min) shouldEqual Patch
-      .Result
-      .apply((), SeqNr.Min, List.empty, (), "a")
-      .pure[Id]
+      .run((), SeqNr.Min) shouldEqual
+      Patch
+        .Result
+        .apply((), SeqNr.Min, List.empty, (), "a")
+        .pure[Id]
   }
 
   test("map") {
@@ -161,15 +169,16 @@ class PatchTest extends AnyFunSuite with Matchers {
     ()
       .patch
       .map { _.toString }
-      .run((), SeqNr.Min) shouldEqual Patch
-      .Result
-      .apply((), SeqNr.Min, List.empty, (), "()")
-      .pure[Id]
+      .run((), SeqNr.Min) shouldEqual
+      Patch
+        .Result
+        .apply((), SeqNr.Min, List.empty, (), "()")
+        .pure[Id]
   }
 
   test("seqNr") {
-    implicit val P      = Patch.Maker[Id, Unit, Unit]
-    implicit val change = Patch.Change.const[Unit](().pure[Id])
+    implicit val P = Patch.Maker[Id, Unit, Unit]
+    implicit val change: Patch.Change[Id, Unit, Unit] = Patch.Change.const[Unit](().pure[Id])
     val patch = for {
       a <- P.seqNr
       _ <- ().patchEvent
@@ -193,8 +202,10 @@ class PatchTest extends AnyFunSuite with Matchers {
   }
 
   test("event") {
-    implicit val P      = Patch.Maker[Id, Int, Int]
-    implicit val change = Patch.Change[Int, Int] { (state, _, event) => (state + event).pure[Id] }
+    implicit val P = Patch.Maker[Id, Int, Int]
+    implicit val change: Patch.Change[Id, Int, Int] = Patch.Change[Int, Int] { (state, _, event) =>
+      (state + event).pure[Id]
+    }
     val patch = for {
       a <- P.state
       _ <- 1.patchEvent
@@ -278,9 +289,9 @@ class PatchTest extends AnyFunSuite with Matchers {
   }
 
   test("effect with custom derivation") {
-    implicit val P                  = Patch.Maker[Id, Unit, Unit]
-    val `+` : Derive[Int, Int, Int] = _ + _
-    val `-` : Derive[Int, Int, Int] = _ - _
+    implicit val P = Patch.Maker[Id, Unit, Unit]
+    val `+`: Derive[Int, Int, Int] = _ + _
+    val `-`: Derive[Int, Int, Int] = _ - _
     val patch = 0
       .patchEffect
       .flatMap { _ =>
@@ -332,7 +343,7 @@ class PatchTest extends AnyFunSuite with Matchers {
 
   test("orElse") {
     implicit val P = Patch.Maker[Either[Unit, *], Int, Int]
-    implicit val change = Patch.Change[Int, Int] { (s, _, e) =>
+    implicit val change: Patch.Change[Either[Unit, *], Int, Int] = Patch.Change[Int, Int] { (s, _, e) =>
       val s1 = s + e
       if (s1 >= 0) s1.asRight[Unit]
       else ().asLeft[Int]
@@ -368,15 +379,16 @@ class PatchTest extends AnyFunSuite with Matchers {
     } yield {}
 
     patch
-      .run(List.empty, SeqNr.Min) shouldEqual Patch
-      .Result
-      .apply(
-        state  = List(("c", 2), ("b", 1), ("a", 0)),
-        seqNr  = 3L,
-        events = List(0, 1, 2),
-        effect = ((0, 1), 2),
-        value  = ()
-      )
+      .run(List.empty, SeqNr.Min) shouldEqual
+      Patch
+        .Result
+        .apply(
+          state = List(("c", 2), ("b", 1), ("a", 0)),
+          seqNr = 3L,
+          events = List(0, 1, 2),
+          effect = ((0, 1), 2),
+          value = (),
+        )
   }
 
   test("apply") {
@@ -387,8 +399,8 @@ class PatchTest extends AnyFunSuite with Matchers {
   }
 
   test("flatMap stacksafe") {
-    implicit val P      = Patch.Maker[Id, Unit, Unit]
-    implicit val change = Patch.Change[Unit, Unit] { (_, _, _) => ().pure[Id] }
+    implicit val P = Patch.Maker[Id, Unit, Unit]
+    implicit val change: Patch.Change[Id, Unit, Unit] = Patch.Change[Unit, Unit] { (_, _, _) => ().pure[Id] }
     val patch = for {
       _ <- P.state
       _ <- P.event(())
@@ -409,8 +421,8 @@ class PatchTest extends AnyFunSuite with Matchers {
   }
 
   test("tailRecM stacksafe") {
-    implicit val P      = Patch.Maker[IO, Unit, Unit]
-    implicit val change = Patch.Change[Unit, Unit] { (_, _, _) => ().pure[IO] }
+    implicit val P = Patch.Maker[IO, Unit, Unit]
+    implicit val change: Patch.Change[IO, Unit, Unit] = Patch.Change[Unit, Unit] { (_, _, _) => ().pure[IO] }
     val patch = for {
       _ <- P.state
       _ <- P.event(())
@@ -458,9 +470,10 @@ class PatchTest extends AnyFunSuite with Matchers {
     }
 
     patch
-      .run((), SeqNr.Min) shouldEqual Patch.Result
-      .apply((), SeqNr.Min, List.empty, (), ("ok".some, none))
-      .asRight
+      .run((), SeqNr.Min) shouldEqual
+      Patch.Result
+        .apply((), SeqNr.Min, List.empty, (), ("ok".some, none))
+        .asRight
   }
 
   test("attempt") {
@@ -479,8 +492,9 @@ class PatchTest extends AnyFunSuite with Matchers {
     }
 
     patch
-      .run((), SeqNr.Min) shouldEqual Patch.Result
-      .apply((), SeqNr.Min, List.empty, (), ("ok".asRight, "ko".asLeft))
-      .asRight
+      .run((), SeqNr.Min) shouldEqual
+      Patch.Result
+        .apply((), SeqNr.Min, List.empty, (), ("ok".asRight, "ko".asLeft))
+        .asRight
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "0.1.3-SNAPSHOT"


### PR DESCRIPTION
* drop Scala 2.12 support
* add Scala 3 support
* switch to common release workflow
* add version policyt and scalafmt checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Compatibility**
  - Updated supported Scala versions and refreshed core development and testing tools.
  - Improved compatibility checks and added streamlined formatting commands.

- **Release Automation**
  - Improved continuous integration and dependency-graph workflows.
  - Release publishing now occurs automatically for version tags.

- **Code Quality**
  - Added consistent Scala formatting standards across production and test code.
  - Standardized style throughout the public codebase without changing runtime behavior.

- **Maintenance**
  - Removed obsolete release and coverage automation in favor of updated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->