### PR TITLE
[AFTER 0.1.3] restore version policy intention to BinaryCompatible after first Scala 3 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,13 +60,7 @@ licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
 versionScheme := Some("early-semver")
 
-versionPolicyIntention := {
-  // TODO temporary disable bin-compat check for first Scala 3 build
-  scalaBinaryVersion.value match {
-    case "2.13" => Compatibility.BinaryCompatible
-    case _ => Compatibility.None
-  }
-}
+versionPolicyIntention := Compatibility.BinaryCompatible
 
 addCommandAlias("check", "+all scalafmtCheckRepo versionPolicyCheck Compile/doc")
 addCommandAlias("fmt", "scalafmtRepo")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Compatibility**
  * Binary compatibility checks are now consistently enabled across supported Scala versions.
  * Scala 3 builds no longer use the temporary compatibility exemption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->